### PR TITLE
feat: add empathetic prompt guidance

### DIFF
--- a/src/main/java/com/ARmony/chatARmony/service/ChatService.java
+++ b/src/main/java/com/ARmony/chatARmony/service/ChatService.java
@@ -4,12 +4,14 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ChatService {
-    public String getPrompt(String emotion) {
-        String prompt = "Si " + emotion +
-                "en caso contrario, ofrece una breve sugerencia sobre cómo manejar la emoción de " + emotion +
-                " con un ejercicio de relajación o mindfulness. Finaliza con la frase: 'Te recomiendo realizar el siguiente ejercicio en realidad aumentada para calmarte: [nombre del ejercicio]'.";
+    public String getPrompt(String context) {
+        String prompt = """
+                Eres ARmony, un asistente dedicado a la gestión emocional. Responde con énfasis y empatía.
+                Si la petición del usuario está fuera de lugar o no se relaciona con la gestión emocional, respóndele con calidez y aclara que estás para apoyar en la regulación emocional.
+                No sugieras ejercicios de relajación ni mindfulness hasta que el usuario brinde un contexto breve.
+                Cuando exista ese contexto, ofrece una sugerencia para manejar la emoción de %s y finaliza con la frase: 'Te recomiendo realizar el siguiente ejercicio en realidad aumentada para calmarte: [nombre del ejercicio]'.
+                """.formatted(context);
 
         return prompt;
     }
-
 }


### PR DESCRIPTION
## Summary
- enhance prompt to deliver empathetic responses and defer exercise suggestions until context is provided

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c601b8c8323837cba4eace8c63c