### PR TITLE
feat: cycle AR exercise suggestions

### DIFF
--- a/src/main/java/com/ARmony/chatARmony/service/ChatService.java
+++ b/src/main/java/com/ARmony/chatARmony/service/ChatService.java
@@ -4,12 +4,22 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ChatService {
-    public String getPrompt(String emotion) {
-        String prompt = "Si " + emotion +
-                "en caso contrario, ofrece una breve sugerencia sobre cómo manejar la emoción de " + emotion +
-                " con un ejercicio de relajación o mindfulness. Finaliza con la frase: 'Te recomiendo realizar el siguiente ejercicio en realidad aumentada para calmarte: [nombre del ejercicio]'.";
+
+    private int messageCount = 0;
+
+    public String getPrompt(String context) {
+        messageCount++;
+        String prompt = """
+                Eres ARmony, un asistente dedicado a la gestión emocional. Responde con énfasis y empatía.
+                Si la petición del usuario está fuera de lugar o no se relaciona con la gestión emocional, respóndele con calidez y aclara que estás para apoyar en la regulación emocional.
+                No sugieras ejercicios de relajación ni mindfulness hasta que el usuario brinde un contexto breve.
+                Cuando exista ese contexto, ofrece una sugerencia para manejar la emoción de %s.
+                """.formatted(context);
+
+        if (messageCount % 3 == 0) {
+            prompt += " Te recomiendo realizar el siguiente ejercicio en realidad aumentada para calmarte: [nombre del ejercicio].";
+        }
 
         return prompt;
     }
-
 }

--- a/src/test/java/com/ARmony/chatARmony/service/ChatServiceTest.java
+++ b/src/test/java/com/ARmony/chatARmony/service/ChatServiceTest.java
@@ -1,0 +1,20 @@
+package com.ARmony.chatARmony.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatServiceTest {
+
+    @Test
+    void recommendsExerciseEveryThirdMessage() {
+        ChatService service = new ChatService();
+        String first = service.getPrompt("tristeza");
+        String second = service.getPrompt("tristeza");
+        String third = service.getPrompt("tristeza");
+
+        assertThat(first).doesNotContain("ejercicio en realidad aumentada");
+        assertThat(second).doesNotContain("ejercicio en realidad aumentada");
+        assertThat(third).contains("Te recomiendo realizar el siguiente ejercicio en realidad aumentada");
+    }
+}


### PR DESCRIPTION
## Summary
- add counter to deliver AR exercise recommendations every third message while maintaining empathetic prompt
- add unit test confirming AR exercise suggestion only appears on third message

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c601b8c8323837cba4eace8c63c